### PR TITLE
fix: Enable setup on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore post-setup stuff
+*/*.egg-info
+package/build

--- a/package/setup.py
+++ b/package/setup.py
@@ -8,7 +8,10 @@ environment = [
     'scipy',
     'nltk',
     'keras==2.8',
-    'tensorflow==2.8',
+    'tensorflow==2.8;sys_platform!="darwin"',
+    'tensorflow-macos==2.8;sys_platform=="darwin"',
+    # cf. https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly
+    'protobuf==3.20.*',
     'torch',
     'transformers',
     'sentencepiece',


### PR DESCRIPTION
Allows this package to be installed on macOS.

## Changes

* Differentiate the `tensorflow` dependency to use the regular `tensorflow`-package on non-macOS systems and for macOS switch to the dedicated package `tensorflow-macos`.
* Add a constraint for `protobuf==3.20.*` to fix some obscure errors in the `keras`-dependency that seem to be platform-independent
* Add a `.gitignore` to ignore build artifacts that are generated during setup